### PR TITLE
Set lower_case_table_names = 1 in my.cnf

### DIFF
--- a/vagrant/etc/my.cnf
+++ b/vagrant/etc/my.cnf
@@ -29,6 +29,9 @@ interactive_timeout = 300
 connect_timeout = 300
 max_connections = 150
 
+# Configure table names to be stored in lowercase on disk and name comparisons to be NOT case sensitive.
+lower_case_table_names = 1
+
 [mysqldump]
 max_allowed_packet = 16M
 


### PR DESCRIPTION
@davidalger 
Facilitates mixed-case table name usage in Magento.