### PR TITLE
Feature/nginx timeout

### DIFF
--- a/vagrant/etc/nginx/default.d/proxy.conf
+++ b/vagrant/etc/nginx/default.d/proxy.conf
@@ -18,6 +18,8 @@ location ~ \.php$ {
     proxy_set_header Host $host;
     
     proxy_pass  http://127.0.0.1:8080;
+    
+    proxy_read_timeout 600;
 }
 
 # deny access to .htaccess files, if Apache's document root concurs with nginx's one


### PR DESCRIPTION
Increase the timeout that nginx waits for php processed files to respond from the default of 60 seconds to 10 minutes.