### PR TITLE
Decrease xdebug.var_display_max_depth value

### DIFF
--- a/vagrant/etc/php.d/15-xdebug.ini
+++ b/vagrant/etc/php.d/15-xdebug.ini
@@ -8,7 +8,7 @@ xdebug.remote_enable=on
 xdebug.remote_host=dev-host
 xdebug.idekey=PHPSTORM
 xdebug.show_local_vars=on
-xdebug.var_display_max_depth=5
+xdebug.var_display_max_depth=3
 xdebug.max_nesting_level=250
 ; xdebug.show_exception_trace=on
 


### PR DESCRIPTION
This PR changes the xdebug.var_display_max_depth value from 5 to 3, which is the [default xdebug value](http://xdebug.org/docs/all_settings#var_display_max_depth). I considered removing the setting altogether, but left it to make it easier for a developer who wanted to tweak the value locally.

When this value is set at 5, it results in massive error dumps in Magento 2. When errors happen in XHR requests and the Chrome network panel is open, that Chrome tab frequently crashes.

I tested the setting at different values to demonstrate and it seems like 3 is a good balance between robust information vs size.

xdebug.var_display_max_depth value | # lines in response
---------------------------------- | -------------------
2 | 1,652
3 | 5,918
4 | 44,235
5 | 273,426