### PR TITLE
Xdebug file links open in PhpStorm

### DIFF
--- a/vagrant/etc/php.d/15-xdebug.ini
+++ b/vagrant/etc/php.d/15-xdebug.ini
@@ -11,6 +11,7 @@ xdebug.show_local_vars=on
 xdebug.var_display_max_depth=3
 xdebug.max_nesting_level=250
 ; xdebug.show_exception_trace=on
+xdebug.file_link_format = "phpstorm://open?file=%f&line=%l"
 
 xdebug.profiler_enable=0
 xdebug.profiler_output_dir="/tmp"


### PR DESCRIPTION
This PR implements support for xdebug's `file_link_format` to open a file in PhpStorm.