### PR TITLE
php.ini change for higher max_input_vars value

### DIFF
--- a/vagrant/etc/php.d/00-php.ini
+++ b/vagrant/etc/php.d/00-php.ini
@@ -5,6 +5,7 @@ error_reporting = E_ALL ^ E_DEPRECATED
 memory_limit = 1G
 date.timezone = UTC
 session.gc_maxlifetime = 7200
+max_input_vars = 16384
 openssl.cafile = /etc/pki/tls/certs/ca-bundle.crt
 
 [phar]


### PR DESCRIPTION
The default was 1000 and we've run into a situation where it needed to be larger