### PR TITLE
Fix issue with sendmail 60 second timeout due to unqualified hostname

### DIFF
--- a/vagrant/etc/hosts
+++ b/vagrant/etc/hosts
@@ -2,11 +2,11 @@
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 
 10.19.89.1  dev-host
-10.19.89.10 dev-web
-10.19.89.11 dev-web55
-10.19.89.12 dev-web54
-10.19.89.13 dev-web53
-10.19.89.14 dev-web70
+10.19.89.10 dev-web.localdomain dev-web
+10.19.89.11 dev-web55.localdomain dev-web55
+10.19.89.12 dev-web54.localdomain dev-web54
+10.19.89.13 dev-web53.localdomain dev-web53
+10.19.89.14 dev-web70.localdomain dev-web70
 10.19.89.20 dev-db
 10.19.89.21 dev-db51
 10.19.89.30 dev-solr

--- a/vagrant/etc/hosts
+++ b/vagrant/etc/hosts
@@ -2,11 +2,11 @@
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 
 10.19.89.1  dev-host
-10.19.89.10 dev-web.localdomain dev-web
-10.19.89.11 dev-web55.localdomain dev-web55
-10.19.89.12 dev-web54.localdomain dev-web54
-10.19.89.13 dev-web53.localdomain dev-web53
-10.19.89.14 dev-web70.localdomain dev-web70
+10.19.89.10 dev-web dev-web.localdomain
+10.19.89.11 dev-web55 dev-web55.localdomain
+10.19.89.12 dev-web54 dev-web54.localdomain
+10.19.89.13 dev-web53 dev-web53.localdomain
+10.19.89.14 dev-web70 dev-web70.localdomain
 10.19.89.20 dev-db
 10.19.89.21 dev-db51
 10.19.89.30 dev-solr


### PR DESCRIPTION
This pull request fixes the issue with sendmail taking 60 seconds to run due to timing out based on an unqualified hostname.

Before this fix, running `php -r "mail('example@example.com', 'test subject', 'test body');"` would take ~60 seconds and this error message would show up in `/var/log/maillog`:

```
Feb 24 20:46:41 dev-web sendmail[10754]: unable to qualify my own domain name (dev-web) -- using short name
```

After this fix is in place, sendmail runs without any delay.

More reading on the source of the cause of this issue http://selliott.org/node/40
