### PR TITLE
Change m2setup.sh to use setup:di:compile

### DIFF
--- a/vagrant/guest/bin/m2setup.sh
+++ b/vagrant/guest/bin/m2setup.sh
@@ -373,7 +373,13 @@ fi
 
 echo "==> Recompiling DI and static content"
 rm -rf var/di/ var/generation/
-bin/magento setup:di:compile $NOISE_LEVEL
+# Magento 2.0.x required usage of multi-tenant compiler (see here for details: http://bit.ly/21eMPtt).
+# Magento 2.1 dropped support for the multi-tenant compiler, so we must use the normal compiler.
+if [ `bin/magento setup:di:compile-multi-tenant --help &> /dev/null; echo $?` -eq 0 ]; then
+    bin/magento setup:di:compile-multi-tenant $NOISE_LEVEL
+else
+    bin/magento setup:di:compile $NOISE_LEVEL
+fi
 bin/magento setup:static-content:deploy $NOISE_LEVEL
 bin/magento cache:flush $NOISE_LEVEL
 

--- a/vagrant/guest/bin/m2setup.sh
+++ b/vagrant/guest/bin/m2setup.sh
@@ -373,7 +373,7 @@ fi
 
 echo "==> Recompiling DI and static content"
 rm -rf var/di/ var/generation/
-bin/magento setup:di:compile-multi-tenant $NOISE_LEVEL
+bin/magento setup:di:compile $NOISE_LEVEL
 bin/magento setup:static-content:deploy $NOISE_LEVEL
 bin/magento cache:flush $NOISE_LEVEL
 


### PR DESCRIPTION
Multi-tenant compile was removed in 2.1, so running m2setup.sh caused an error.

![sites ssh vcd 176x48-n7b83](https://cloud.githubusercontent.com/assets/129031/16312819/16b018e6-393c-11e6-9b9c-8b7fc5b19df6.png)

