### PR TITLE
Add lsof command to guest VMS

### DIFF
--- a/vagrant/scripts/node.sh
+++ b/vagrant/scripts/node.sh
@@ -109,7 +109,7 @@ fi
 :: installing generic guest tooling
 ########################################
 
-yum install -y bash-completion bc man git rsync mysql pv tree
+yum install -y bash-completion bc man git rsync mysql pv tree lsof
 rsync -av --ignore-existing ./guest/bin/ /usr/local/bin/
 
 ########################################


### PR DESCRIPTION
The Magento Enterprise Support backup tool requires lsof, thus the impetus for submitting this PR.

![magento admin-d2470](https://cloud.githubusercontent.com/assets/129031/16662996/ef260b78-443f-11e6-8608-45032c6bac39.png)
