### PR TITLE
Updates to support Ansible 2.7

### DIFF
--- a/vagrant/provisioning/roles/alpacaglue.nginx/tasks/configure-nginx.yml
+++ b/vagrant/provisioning/roles/alpacaglue.nginx/tasks/configure-nginx.yml
@@ -21,7 +21,7 @@
 
 - name: configure vhosts
   include_tasks: nginx-vhost.yml
-  args:
+  vars:
     vhost_name: "{{ item.name }}"
     vhost_pool: "{{ item.pool }}"
     vhost_params: "{{ item.params|default({}) }}"
@@ -31,7 +31,7 @@
 
 - name: configure backends
   include_tasks: nginx-backend.yml
-  args:
+  vars:
     backend_name: "{{ item.name }}"
     backend_pool: "{{ item.pool }}"
     backend_listen: "{{ item.listen }}"
@@ -42,7 +42,7 @@
 
 - name: configure domain redirects
   include_tasks: domain-redirect.yml
-  args:
+  vars:
     redirect_domain: "{{ item.domain }}"
     redirect_target: "{{ item.target }}"
     redirect_include_uri: "{{ item.include_uri|default(false) }}"

--- a/vagrant/provisioning/roles/alpacaglue.nginx/tasks/configure-ssl.yml
+++ b/vagrant/provisioning/roles/alpacaglue.nginx/tasks/configure-ssl.yml
@@ -29,17 +29,17 @@
 
 - name: selfsign default certificate
   include_tasks: ssl-selfsign.yml
-  args:
+  vars:
     common_name: default
 
 - name: selfsign ssl certificates
   include_tasks: ssl-selfsign.yml
-  args:
+  vars:
     common_name: "{{ item.name }}"
   with_items: "{{ nginx_vhosts }}"
 
 - name: selfsign ssl certificates (domain redirects)
   include_tasks: ssl-selfsign.yml
-  args:
+  vars:
     common_name: "{{ item.domain }}"
   with_items: "{{ nginx_domain_redirects }}"

--- a/vagrant/provisioning/roles/alpacaglue.php-fpm/defaults/main.yml
+++ b/vagrant/provisioning/roles/alpacaglue.php-fpm/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Valid values are 55, 56, 70, 71 and 72
 php_version: 70
-php_enablerepo: null
+php_enablerepo: ius
 
 # List of php modules to install
 php_default_modules:

--- a/vagrant/provisioning/roles/alpacaglue.php-fpm/tasks/main.yml
+++ b/vagrant/provisioning/roles/alpacaglue.php-fpm/tasks/main.yml
@@ -7,7 +7,9 @@
   when: php_version >= 72
 
 - name: install php-fpm
-  yum: name=php{{ php_version }}u-fpm enablerepo={{ php_enablerepo }}
+  yum: 
+    name: "php{{ php_version }}u-fpm" 
+    enablerepo: "{{ php_enablerepo }}"
 
 - name: install php modules
   yum: name=php{{ php_version }}u-{{ item }} enablerepo={{ php_enablerepo }}

--- a/vagrant/provisioning/roles/alpacaglue.redis/defaults/main.yml
+++ b/vagrant/provisioning/roles/alpacaglue.redis/defaults/main.yml
@@ -3,7 +3,7 @@ redis_version: 32
 redis_package_name: "redis{{ redis_version }}u"
 
 # This can be set to "ius-archive" to allow installation of older redis30u package
-redis_enablerepo:
+redis_enablerepo: ius
 
 redis_instance:
   name: obj


### PR DESCRIPTION
Updates for supporting Ansible 2.7 which ends up getting installed in the VM when it is built and is what runs the playbooks from ansible_local in the vagrant configs.